### PR TITLE
Add temporary fix for Travis OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: csharp
 branches:
   except:
   - /^[0-9]/
-services:
-  - docker
 env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -11,13 +9,19 @@ env:
 matrix:
   include:
     - os: linux
-      sudo: required
       dotnet: 2.0.0
     - os: osx 
       osx_image: xcode9 # OSX 10.12
-      dotnet: 2.0.0
+      before_install:
+        - brew update
+        - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+        - chmod +x dotnet-install.sh
+        - ./dotnet-install.sh --channel 2.0
+        - export PATH=$PATH:~/.dotnet/
 script:
-  - ./build.sh
+  - dotnet restore
+  - dotnet build --configuration Release
+  - dotnet test test/Winton.AspNetCore.Seo.Tests/ --no-build --configuration Release --framework netcoreapp2.0
 notifications:
   on_success: always
   on_failure: always

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-set -e
-
-dotnet restore
-dotnet build --configuration Release
-dotnet test test/Winton.AspNetCore.Seo.Tests/ --no-build --configuration Release --framework netcoreapp2.0


### PR DESCRIPTION
Addresses #11 

Fixes Travis OS X build by manually installing the dotnet SDK on OS X, so that `brew update` can be run before dotnet is installed.