### PR TITLE
Add ability to set Noindex directive in robots.txt file.

### DIFF
--- a/src/Winton.AspNetCore.Seo/Robots/RobotsTxtFactory.cs
+++ b/src/Winton.AspNetCore.Seo/Robots/RobotsTxtFactory.cs
@@ -26,18 +26,18 @@ namespace Winton.AspNetCore.Seo.Robots
             foreach (UserAgentRecord userAgentRecord in _options.UserAgentRecords ??
                                                         Enumerable.Empty<UserAgentRecord>())
             {
-                stringBuilder.AppendLine(userAgentRecord.CreateRecord());
+                stringBuilder.AppendLine(userAgentRecord.ToString());
             }
 
             if (_options.AddSitemapUrl)
             {
-                stringBuilder.AppendLine(AddSitemapUrl());
+                stringBuilder.AppendLine(CreateSitemapUrl());
             }
 
             return stringBuilder.ToString();
         }
 
-        private string AddSitemapUrl()
+        private string CreateSitemapUrl()
         {
             string baseUrl = _httpContextAccessor?.HttpContext?.Request?.GetEncodedUrl();
             Url sitemapUrl = (baseUrl ?? string.Empty).Replace(Constants.RobotsUrl, Constants.SitemapUrl);

--- a/src/Winton.AspNetCore.Seo/Robots/UserAgentRecord.cs
+++ b/src/Winton.AspNetCore.Seo/Robots/UserAgentRecord.cs
@@ -23,11 +23,20 @@ namespace Winton.AspNetCore.Seo.Robots
         public bool DisallowAll { get; set; }
 
         /// <summary>
+        ///     Gets or sets the URLs that should not be indexed by this <see cref="UserAgent" />.
+        /// </summary>
+        public IEnumerable<string> NoIndex { get; set; }
+
+        /// <summary>
         ///     Gets or sets the <see cref="UserAgent" /> to which the record applies. Defaults to <code>UserAgent.Any</code>.
         /// </summary>
         public UserAgent UserAgent { get; set; } = UserAgent.Any;
 
-        internal string CreateRecord()
+        /// <summary>
+        ///     Creates a string representation of the <see cref="UserAgentRecord" />.
+        /// </summary>
+        /// <returns>The string.</returns>
+        public override string ToString()
         {
             StringBuilder stringBuilder = new StringBuilder()
                 .AppendLine($"User-agent: {UserAgent}");
@@ -39,6 +48,11 @@ namespace Winton.AspNetCore.Seo.Robots
             foreach (string url in disallowedUrls)
             {
                 stringBuilder.AppendLine($"Disallow: {url}");
+            }
+
+            foreach (string url in NoIndex ?? Enumerable.Empty<string>())
+            {
+                stringBuilder.AppendLine($"Noindex: {url}");
             }
 
             return stringBuilder.ToString();

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/RobotsTxtFactoryTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/RobotsTxtFactoryTest.cs
@@ -23,7 +23,7 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
         public sealed class Create : RobotsTxtFactoryTest
         {
             [Fact]
-            private void ShouldAddAllUserAgentRecords()
+            private void ShouldAddAllUserAgentRecordsSeperatedByABlankLine()
             {
                 var userAgentRecords = new List<UserAgentRecord>
                 {

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/UserAgentRecordTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/UserAgentRecordTest.cs
@@ -7,17 +7,16 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
 {
     public class UserAgentRecordTest
     {
-        public sealed class CreateRecord : UserAgentRecordTest
+        public new sealed class ToString : UserAgentRecordTest
         {
             [Fact]
             private void ShouldAllowAllRoutesIfDisallowNotSet()
             {
                 var userAgentRecord = new UserAgentRecord();
 
-                string section = userAgentRecord.CreateRecord();
+                string record = userAgentRecord.ToString();
 
-                section.Should().Contain("Disallow:");
-                section.Should().NotContain("Disallow: /");
+                record.Should().Contain("Disallow:").And.NotContain("Disallow: /");
             }
 
             [Fact]
@@ -29,9 +28,9 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
                     Disallow = new List<string> { "/test" }
                 };
 
-                string section = userAgentRecord.CreateRecord();
+                string record = userAgentRecord.ToString();
 
-                section.Should().Contain("Disallow: /");
+                record.Should().Contain("Disallow: /");
             }
 
             [Fact]
@@ -42,10 +41,9 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
                     Disallow = new List<string> { "/test", "/foo" }
                 };
 
-                string section = userAgentRecord.CreateRecord();
+                string record = userAgentRecord.ToString();
 
-                section.Should().Contain("Disallow: /test");
-                section.Should().Contain("Disallow: /foo");
+                record.Should().Contain("Disallow: /test").And.Contain("Disallow: /foo");
             }
 
             [Theory]
@@ -58,9 +56,22 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
                     UserAgent = (UserAgent)userAgent
                 };
 
-                string section = userAgentRecord.CreateRecord();
+                string record = userAgentRecord.ToString();
 
-                section.Should().Contain($"User-agent: {userAgent}");
+                record.Should().Contain($"User-agent: {userAgent}");
+            }
+
+            [Fact]
+            private void ShouldContainNoindexDirectiveIfDefinedForUrl()
+            {
+                var userAgentRecord = new UserAgentRecord
+                {
+                    NoIndex = new List<string> { "/test", "/foo" }
+                };
+
+                string record = userAgentRecord.ToString();
+
+                record.Should().Contain("Noindex: /test").And.Contain("Noindex: /foo");
             }
         }
 


### PR DESCRIPTION
Addresses #13 

Changes:
* Add a `NoIndex` property to `UserAgentRecord` that is used to produce the `Noindex:` lines for a user agent record in a robots.txt file.