### PR TITLE
Simplify test namespaces

### DIFF
--- a/Winton.AspNetCore.Seo.sln
+++ b/Winton.AspNetCore.Seo.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2002
@@ -22,7 +21,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Winton.AspNetCore.Seo", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Winton.AspNetCore.Seo.Tests", "test\Winton.AspNetCore.Seo.Tests\Winton.AspNetCore.Seo.Tests.csproj", "{FEF7A97C-DC75-4B87-A53F-6990F7DDB775}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Winton.AspNetCore.Seo.IntegrationTests", "test\Winton.AspNetCore.Seo.IntegrationTests\Winton.AspNetCore.Seo.IntegrationTests.csproj", "{5355C84C-9CD9-4FF2-9CFF-2B0420E56F02}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Winton.AspNetCore.Seo.IntegrationTests", "test\Winton.AspNetCore.Seo.IntegrationTests\Winton.AspNetCore.Seo.IntegrationTests.csproj", "{5355C84C-9CD9-4FF2-9CFF-2B0420E56F02}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Winton.AspNetCore.Seo/HeaderMetadata/OpenGraph/Audio.cs
+++ b/src/Winton.AspNetCore.Seo/HeaderMetadata/OpenGraph/Audio.cs
@@ -10,7 +10,7 @@ namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
     public sealed class Audio : Media
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="Audio"/> class.
+        ///     Initializes a new instance of the <see cref="Audio" /> class.
         /// </summary>
         /// <param name="url">The url of the media Open Graph object.</param>
         public Audio(string url)

--- a/src/Winton.AspNetCore.Seo/HeaderMetadata/OpenGraph/OpenGraphProperty.cs
+++ b/src/Winton.AspNetCore.Seo/HeaderMetadata/OpenGraph/OpenGraphProperty.cs
@@ -40,7 +40,10 @@ namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
                 case DateTime dateTime:
                     return new List<MetaTag> { new MetaTag(FullName, dateTime.ToString("o")) };
                 case IConvertible convertible:
-                    return new List<MetaTag> { new MetaTag(FullName, Convert.ToString(convertible, CultureInfo.InvariantCulture)) };
+                    return new List<MetaTag>
+                    {
+                        new MetaTag(FullName, Convert.ToString(convertible, CultureInfo.InvariantCulture))
+                    };
                 case IEnumerable<object> enumerable:
                     return enumerable.SelectMany(x => new OpenGraphProperty(FullName, IsPrimary, x).ToMetaTags());
                 default:

--- a/test/Winton.AspNetCore.Seo.IntegrationTests/SeoControllerIntegrationTest.cs
+++ b/test/Winton.AspNetCore.Seo.IntegrationTests/SeoControllerIntegrationTest.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.IntegrationTests
+namespace Winton.AspNetCore.Seo
 {
     public class SeoControllerIntegrationTest
     {

--- a/test/Winton.AspNetCore.Seo.IntegrationTests/SitemapConfig.cs
+++ b/test/Winton.AspNetCore.Seo.IntegrationTests/SitemapConfig.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Winton.AspNetCore.Seo.Sitemaps;
 
-namespace Winton.AspNetCore.Seo.IntegrationTests
+namespace Winton.AspNetCore.Seo
 {
     internal sealed class SitemapConfig : ISitemapConfig
     {

--- a/test/Winton.AspNetCore.Seo.IntegrationTests/Startup.cs
+++ b/test/Winton.AspNetCore.Seo.IntegrationTests/Startup.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Winton.AspNetCore.Seo.Extensions;
 
-namespace Winton.AspNetCore.Seo.IntegrationTests
+namespace Winton.AspNetCore.Seo
 {
     internal class Startup : IStartup
     {

--- a/test/Winton.AspNetCore.Seo.IntegrationTests/Winton.AspNetCore.Seo.IntegrationTests.csproj
+++ b/test/Winton.AspNetCore.Seo.IntegrationTests/Winton.AspNetCore.Seo.IntegrationTests.csproj
@@ -4,6 +4,7 @@
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <IsPackable>False</IsPackable>
     <NoWarn>$(NoWarn);SA0001;SA1101;SA1309;SA1413;SA1633;SA1652</NoWarn>
+    <RootNamespace>Winton.AspNetCore.Seo</RootNamespace>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicAlbumTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicAlbumTagHelperTests.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Music
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music
 {
     public class OpenGraphMusicAlbumTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicPlaylistTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicPlaylistTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Music
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music
 {
     public class OpenGraphMusicPlaylistTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicRadioStationTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicRadioStationTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Music
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music
 {
     public class OpenGraphMusicRadioStationTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicSongTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Music/OpenGraphMusicSongTagHelperTests.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Music
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Music
 {
     public class OpenGraphMusicSongTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphArticleTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphArticleTagHelperTests.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class OpenGraphArticleTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphBookTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphBookTagHelperTests.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class OpenGraphBookTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphProfileTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphProfileTagHelperTests.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class OpenGraphProfileTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphPropertyTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphPropertyTests.cs
@@ -3,10 +3,9 @@
 
 using System.Reflection;
 using FluentAssertions;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class OpenGraphPropertyTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphTagHelperTests.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class OpenGraphTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphWebsiteTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/OpenGraphWebsiteTagHelperTests.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class OpenGraphWebsiteTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/PropertyInfoExtensionsTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/PropertyInfoExtensionsTests.cs
@@ -2,10 +2,9 @@ using System;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class PropertyInfoExtensionsTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/StringExtensionsTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/StringExtensionsTests.cs
@@ -1,8 +1,7 @@
 using FluentAssertions;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public class StringExtensionsTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/TagHelperOutputAssertions.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/TagHelperOutputAssertions.cs
@@ -6,9 +6,8 @@ using FluentAssertions.Equivalency;
 using FluentAssertions.Primitives;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     internal sealed class TagHelperOutputAssertions :
         ReferenceTypeAssertions<TagHelperOutput, TagHelperOutputAssertions>

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/TagHelperOutputExtensions.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/TagHelperOutputExtensions.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     internal static class TagHelperOutputExtensions
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/TagHelperTestUtils.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/TagHelperTestUtils.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph
 {
     public sealed class TagHelperTestUtils
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoEpisodeTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoEpisodeTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Videos
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos
 {
     public class OpenGraphVideoEpisodeTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoMovieTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoMovieTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Videos
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos
 {
     public class OpenGraphVideoMovieTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoOtherTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoOtherTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Videos
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos
 {
     public class OpenGraphVideoOtherTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Videos
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos
 {
     public class OpenGraphVideoTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoTvShowTagHelperTests.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/HeaderMetadata/OpenGraph/Videos/OpenGraphVideoTvShowTagHelperTests.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph;
-using Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.HeaderMetadata.OpenGraph.Videos
+namespace Winton.AspNetCore.Seo.HeaderMetadata.OpenGraph.Videos
 {
     public class OpenGraphVideoTvShowTagHelperTests
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/DefaultRobotsTxtOptionsTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/DefaultRobotsTxtOptionsTest.cs
@@ -1,10 +1,9 @@
 ﻿using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting.Internal;
-using Winton.AspNetCore.Seo.Robots;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Robots
+namespace Winton.AspNetCore.Seo.Robots
 {
     public class DefaultRobotsTxtOptionsTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/RobotsTxtFactoryTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/RobotsTxtFactoryTest.cs
@@ -3,10 +3,9 @@ using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Moq;
-using Winton.AspNetCore.Seo.Robots;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Robots
+namespace Winton.AspNetCore.Seo.Robots
 {
     public class RobotsTxtFactoryTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/UserAgentRecordTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/UserAgentRecordTest.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
 using FluentAssertions;
-using Winton.AspNetCore.Seo.Robots;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Robots
+namespace Winton.AspNetCore.Seo.Robots
 {
     public class UserAgentRecordTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/UserAgentTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/UserAgentTest.cs
@@ -1,8 +1,7 @@
 ﻿using FluentAssertions;
-using Winton.AspNetCore.Seo.Robots;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Robots
+namespace Winton.AspNetCore.Seo.Robots
 {
     public class UserAgentTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/SeoControllerTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/SeoControllerTest.cs
@@ -5,7 +5,7 @@ using Winton.AspNetCore.Seo.Robots;
 using Winton.AspNetCore.Seo.Sitemaps;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests
+namespace Winton.AspNetCore.Seo
 {
     public class SeoControllerTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Sitemaps/ChangeFrequencyTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Sitemaps/ChangeFrequencyTest.cs
@@ -1,10 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.Serialization;
 using FluentAssertions;
-using Winton.AspNetCore.Seo.Sitemaps;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Sitemaps
+namespace Winton.AspNetCore.Seo.Sitemaps
 {
     public class ChangeFrequencyTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Sitemaps/SitemapFactoryTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Sitemaps/SitemapFactoryTest.cs
@@ -2,10 +2,9 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Moq;
-using Winton.AspNetCore.Seo.Sitemaps;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Sitemaps
+namespace Winton.AspNetCore.Seo.Sitemaps
 {
     public class SitemapFactoryTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Sitemaps/SitemapTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Sitemaps/SitemapTest.cs
@@ -1,10 +1,9 @@
 ﻿using System.Runtime.Serialization;
 using Castle.Core.Internal;
 using FluentAssertions;
-using Winton.AspNetCore.Seo.Sitemaps;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Sitemaps
+namespace Winton.AspNetCore.Seo.Sitemaps
 {
     public class SitemapTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Sitemaps/SitemapUrlTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Sitemaps/SitemapUrlTest.cs
@@ -4,10 +4,9 @@ using System.Runtime.Serialization;
 using Castle.Core.Internal;
 using FluentAssertions;
 using FluentAssertions.Common;
-using Winton.AspNetCore.Seo.Sitemaps;
 using Xunit;
 
-namespace Winton.AspNetCore.Seo.Tests.Sitemaps
+namespace Winton.AspNetCore.Seo.Sitemaps
 {
     public class SitemapUrlTest
     {

--- a/test/Winton.AspNetCore.Seo.Tests/Winton.AspNetCore.Seo.Tests.csproj
+++ b/test/Winton.AspNetCore.Seo.Tests/Winton.AspNetCore.Seo.Tests.csproj
@@ -4,6 +4,7 @@
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <IsPackable>False</IsPackable>
     <NoWarn>$(NoWarn);SA0001;SA1101;SA1309;SA1413;SA1633;SA1652</NoWarn>
+    <RootNamespace>Winton.AspNetCore.Seo</RootNamespace>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
Use the same namespace for tests as for src to simplify using statements.