### PR TITLE
Fix Sitemap directive format in RobotsTxtFactory - 1.3 patch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 
 .vs/
+.vscode/
 
 .idea/
 

--- a/src/Winton.AspNetCore.Seo/Robots/RobotsTxtFactory.cs
+++ b/src/Winton.AspNetCore.Seo/Robots/RobotsTxtFactory.cs
@@ -41,7 +41,7 @@ namespace Winton.AspNetCore.Seo.Robots
         {
             string baseUrl = _httpContextAccessor?.HttpContext?.Request?.GetEncodedUrl();
             Url sitemapUrl = (baseUrl ?? string.Empty).Replace(Constants.RobotsUrl, Constants.SitemapUrl);
-            return $"GetSitemap: {sitemapUrl}";
+            return $"Sitemap: {sitemapUrl}";
         }
     }
 }

--- a/test/Winton.AspNetCore.Seo.Tests/Robots/RobotsTxtFactoryTest.cs
+++ b/test/Winton.AspNetCore.Seo.Tests/Robots/RobotsTxtFactoryTest.cs
@@ -74,7 +74,7 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
 
                 string robotsTxt = robotsFactory.Create();
 
-                robotsTxt.Should().Contain("GetSitemap: https://example.com:5000/app-root/sitemap.xml");
+                robotsTxt.Should().Contain("Sitemap: https://example.com:5000/app-root/sitemap.xml");
             }
 
             [Theory]
@@ -88,7 +88,7 @@ namespace Winton.AspNetCore.Seo.Tests.Robots
 
                 string robotsTxt = robotsFactory.Create();
 
-                robotsTxt.Contains("GetSitemap").Should().Be(expected);
+                robotsTxt.Contains("Sitemap").Should().Be(expected);
             }
 
             [Fact]


### PR DESCRIPTION
Addresses #27 for 1.3 release

* Fixes the format of the Sitemap directive in `RobotsTxtFactory`.